### PR TITLE
Login via kerberos before running ipa-certupdate

### DIFF
--- a/files/setup_freeipa.sh
+++ b/files/setup_freeipa.sh
@@ -81,7 +81,9 @@ function enroll {
 
     # Trust the self-signed FreeIPA CA.  This is run automatically on
     # Fedora but not on Debian.  It doesn't hurt to run it twice.
+    echo "$ADMIN_PW" | kinit admin
     ipa-certupdate
+    kdestroy
 }
 
 function unenroll {


### PR DESCRIPTION
## 🗣 Description

This pull request modifies the `setup_freeipa.sh` script to login via kerberos before running `ipa-certupdate`.

## 💭 Motivation and Context

`ipa-certupdate` doesn't work otherwise.

## 🧪 Testing

I verified that the command works once `kinit` has been run.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
