### PR TITLE
Update certs when rejoining

### DIFF
--- a/files/freeipa-enroll.service
+++ b/files/freeipa-enroll.service
@@ -16,6 +16,9 @@ LimitNPROC=10
 PrivateTmp=true
 ProtectHome=true
 ProtectSystem=true
+# The service must be able to write here in order to make the system
+# trust the FreeIPA CA.
+ReadWritePaths=/usr/local/share/ca-certificates
 RemainAfterExit=yes
 Type=oneshot
 WorkingDirectory=/tmp

--- a/files/setup_freeipa.sh
+++ b/files/setup_freeipa.sh
@@ -78,12 +78,6 @@ function enroll {
                        --no-ntp \
                        --unattended \
                        --force-join
-
-    # Trust the self-signed FreeIPA CA.  This is run automatically on
-    # Fedora but not on Debian.  It doesn't hurt to run it twice.
-    echo "$ADMIN_PW" | kinit admin
-    ipa-certupdate
-    kdestroy
 }
 
 function unenroll {


### PR DESCRIPTION
## 🗣 Description

This pull request fixes a bug where FreeIPA's self-signed CA cert was not being trusted on systems that join the domain as clients via the systemd service.

## 💭 Motivation and Context

The problem turned out to be that the `systemd` service that runs `ipa-client-install` specifies `ProtectSystem=true` in its unit file.  This means that the `/usr` and `/boot` directories are read-only as far as the service is concerned.  For clients, the CA certificates are written to `/usr/local/share/ca-certificates`, and hence that write fails.  This issue didn't appear before because we were using Let's Encrypt certificates everywhere instead of letting IPA create a self-signed CA.

I had previously thought that this was a Fedora versus Debian issue, but it appeared only on our Debian systems because they join the domain via `systemd`; the Fedora systems join the domain outside of `systemd`.

The LDAP request to verify OpenVPN users cannot proceed without this trust in place, so it is critical that this bug be fixed.

## 🧪 Testing

I have verified that the certificates are properly trusted with these changes, whether the server is joining the domain for the first time or simply rejoining.  Together with cisagov/cool-sharedservices-freeipa#13 and rebuilt OpenVPN and Guacamole images, this appears to alleviate the issues that @dav3r and I saw when deploying yesterday.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
