### PR TITLE
Use IMDSv2 when retrieving the instance ID

### DIFF
--- a/files/00_setup_freeipa.sh
+++ b/files/00_setup_freeipa.sh
@@ -31,7 +31,14 @@ fi
 # SSM Session Manager.  First check to make sure the alias does not
 # already exist.
 function add_principal {
+  # Grab the instance ID from the AWS Instance Meta-Data Service
+  # (IMDSv2)
+  imds_token=$(curl --silent \
+      --request PUT \
+      --header "X-aws-ec2-metadata-token-ttl-seconds: 10" \
+    http://169.254.169.254/latest/api/token)
   instance_id=$(curl --silent \
+      --header "X-aws-ec2-metadata-token: $imds_token" \
     http://169.254.169.254/latest/meta-data/instance-id)
 
   # domain and hostname are defined in the FreeIPA variables


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the `00_setup_freeipa.sh` script to use IMDSv2 when retrieving the instance ID from the AWS meta-data service.

## 💭 Motivation and context ##

We want to enforce IMDSv2-only on our instances to satisfy cisagov/cool-system#174 and cisagov/cool-system#175, and this change will help us with that.

## 🧪 Testing ##

* All `pre-commit` hooks and `molecule` tests pass
* I built a new AMI with the new code, deployed it to our COOL staging environment, and verified that it functioned as expected.

## ✅ Checklist ##

* [x] This PR has an informative and human-readable title.
* [x] Changes are limited to a single goal - _eschew scope creep!_
* [x] All relevant type-of-change labels have been added.
* [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
* [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
* [x] All new and existing tests pass.
