### PR TITLE
Amend two files for Debian Bullseye

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 # These owners will be the default owners for everything in the
 # repo. Unless a later match takes precedence, these owners will be
 # requested for review when someone opens a pull request.
-* @dav3r @felddy @jsf9k
+* @dav3r @felddy @jsf9k @mcdonnnj
 
 # These folks own any files in the .github directory at the root of
 # the repository and any of its subdirectories.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,7 +19,7 @@
             name: "{{ package_names }}"
             default_release: "{{ ansible_distribution_release }}-backports"
         # On Debian Bullseye, the default /etc/krb5.conf file uses a
-        # FILE value for this option.  The /krb5.conf file is then
+        # FILE value for this option.  The /etc/krb5.conf file is then
         # overwritten when the 00_setup_freeipa.sh script is run, and
         # the new file uses the KEYRING value specified below.  This
         # causes a problem since before running that script we kinit,

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,6 +29,9 @@
         # the preferred value before the script can ever be run.
         - name: Set default ccache name for Kerberos (Debian Bullseye)
           community.general.ini_file:
+            # These are the permissions that are set by default on
+            # Debian Bullseye.
+            mode: 0644
             option: default_ccache_name
             path: /etc/krb5.conf
             section: libdefaults

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,9 +13,26 @@
 - name: Install FreeIPA client
   block:
     - name: Install FreeIPA client (Debian Bullseye)
-      ansible.builtin.package:
-        name: "{{ package_names }}"
-        default_release: "{{ ansible_distribution_release }}-backports"
+      block:
+        - name: Install FreeIPA client (Debian Bullseye)
+          ansible.builtin.package:
+            name: "{{ package_names }}"
+            default_release: "{{ ansible_distribution_release }}-backports"
+        # On Debian Bullseye, the default /etc/krb5.conf file uses a
+        # FILE value for this option.  The /krb5.conf file is then
+        # overwritten when the 00_setup_freeipa.sh script is run, and
+        # the new file uses the KEYRING value specified below.  This
+        # causes a problem since before running that script we kinit,
+        # which stores our keytab in a file that is then ignored by
+        # Kerberos due to the new configuration.  To avoid this
+        # wrinkle we simply adjust the default configuration to use
+        # the preferred value before the script can ever be run.
+        - name: Set default ccache name for Kerberos (Debian Bullseye)
+          community.general.ini_file:
+            option: default_ccache_name
+            path: /etc/krb5.conf
+            section: libdefaults
+            value: KEYRING:persistent:%{uid}
       when:
         - ansible_distribution == "Debian"
         - ansible_distribution_release == "bullseye"


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies two files for Debian Bullseye.

## 💭 Motivation and context ##

- On Debian Bullseye, the SSSD config file incorrectly contains a line of the form `services = ...` in the `sssd` section.  This line is unnecessary since we are using SystemD, as described [here](https://manpages.debian.org/testing/sssd-common/sssd.conf.5.en.html#The_%5Bsssd%5D_section), and on Debian Bullseye its presence causes a failure.  This is because SystemD tries to enable and start those services, but they are only meant to be triggered when the corresponding SystemD `*.socket` units are activated.
- On Debian Bullseye, the default `/etc/krb5.conf` file uses a `FILE` value for the `default_ccache_name` option.  The `/etc/krb5.conf` file is then overwritten when the `00_setup_freeipa.sh` script is run, and the new file uses a `KEYRING` value.  This causes a problem since before running that script we `kinit`, which stores our keytab in a file that is then ignored by Kerberos due to the new configuration.  To avoid this wrinkle we simply adjust the default configuration to use the preferred value before the script can ever be run.

## 🧪 Testing ##

All automated testing passes.  I also built a COOL staging AMI with these changes, deployed it to env6-staging, and verified that it functioned as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [ ] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.