### PR TITLE
Do not specify backports as the default_release option

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,39 +12,30 @@
 
 - name: Install FreeIPA client
   block:
-    - name: Install FreeIPA client (Debian Bullseye)
-      block:
-        - name: Install FreeIPA client (Debian Bullseye)
-          ansible.builtin.package:
-            name: "{{ package_names }}"
-            default_release: "{{ ansible_distribution_release }}-backports"
-        # On Debian Bullseye, the default /etc/krb5.conf file uses a
-        # FILE value for this option.  The /etc/krb5.conf file is then
-        # overwritten when the 00_setup_freeipa.sh script is run, and
-        # the new file uses the KEYRING value specified below.  This
-        # causes a problem since before running that script we kinit,
-        # which stores our keytab in a file that is then ignored by
-        # Kerberos due to the new configuration.  To avoid this
-        # wrinkle we simply adjust the default configuration to use
-        # the preferred value before the script can ever be run.
-        - name: Set default ccache name for Kerberos (Debian Bullseye)
-          community.general.ini_file:
-            # These are the permissions that are set by default on
-            # Debian Bullseye.
-            mode: 0644
-            option: default_ccache_name
-            path: /etc/krb5.conf
-            section: libdefaults
-            value: KEYRING:persistent:%{uid}
+    - name: Install FreeIPA client
+      ansible.builtin.package:
+        name: "{{ package_names }}"
+    # On Debian Bullseye, the default /etc/krb5.conf file uses a FILE
+    # value for this option.  The /etc/krb5.conf file is then
+    # overwritten when the 00_setup_freeipa.sh script is run, and the
+    # new file uses the KEYRING value specified below.  This causes a
+    # problem since before running that script we kinit, which stores
+    # our keytab in a file that is then ignored by Kerberos due to the
+    # new configuration.  To avoid this wrinkle we simply adjust the
+    # default configuration to use the preferred value before the
+    # script can ever be run.
+    - name: Set default ccache name for Kerberos (Debian Bullseye only)
+      community.general.ini_file:
+        # These are the permissions that are set by default on
+        # Debian Bullseye.
+        mode: 0644
+        option: default_ccache_name
+        path: /etc/krb5.conf
+        section: libdefaults
+        value: KEYRING:persistent:%{uid}
       when:
         - ansible_distribution == "Debian"
         - ansible_distribution_release == "bullseye"
-
-    - name: Install FreeIPA client (not Debian Bullseye)
-      ansible.builtin.package:
-        name: "{{ package_names }}"
-      when:
-        - not (ansible_distribution == "Debian" and ansible_distribution_release == "bullseye")
 
 - name: Copy setup script
   ansible.builtin.copy:


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Ansible code to no longer specify Debian backports as the `default_release` option when installing the `freeipa-client` package on Debian Bullseye.

## 💭 Motivation and context ##

This change is necessary because the `default_release` option does not work in quite the way I thought it did.  I thought it was _necessary_ in order to pull a package out of backports, but it actually causes `apt` to _prefer_ backports over any other repo source.  In the case of `freeipa-client`, the package is _only_ available in backports; hence, it is unnecessary here.  Using it causes _all_ `freeipa-client` dependencies to be installed from backports if at all possible.  This leads to broken behavior, as I described [here](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1011070).

## 🧪 Testing ##

See cisagov/guacamole-packer#80.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.