### PR TITLE
Remove support for Debian Bookworm and Kali Linux

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -21,10 +21,16 @@ galaxy_info:
       versions:
         - buster
         - bullseye
+        # There is currently no freeipa-client package for Debian
+        # Testing (Bookworm) or Kali.  Once Bookworm is actually
+        # released a freeipa-client will appear in bookworm-backports.
+        #
+        # See cisagov/ansible-role-freeipa-client#51
+        #
         # Kali linux isn't an option here, but it is based on
         # Debian Testing:
         # https://www.kali.org/docs/policy/kali-linux-relationship-with-debian
-        - bookworm
+        # - bookworm
     - name: Fedora
       versions:
         - 34

--- a/molecule/default/molecule-no-systemd.yml
+++ b/molecule/default/molecule-no-systemd.yml
@@ -22,10 +22,16 @@ platforms:
     image: debian:buster-slim
   - name: debian11
     image: debian:bullseye-slim
-  - name: debian12
-    image: debian:bookworm-slim
-  - name: kali
-    image: kalilinux/kali-rolling
+  # There is currently no freeipa-client package for Debian Testing
+  # (Bookworm) or Kali.  Once Bookworm is actually released a
+  # freeipa-client will appear in bookworm-backports.
+  #
+  # See cisagov/ansible-role-freeipa-client#51
+  #
+  # - name: debian12
+  #   image: debian:bookworm-slim
+  # - name: kali
+  #   image: kalilinux/kali-rolling
   - name: fedora34
     image: fedora:34
   - name: fedora35


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes support for Debian Bookworm and Kali Linux.

## 💭 Motivation and context ##

There is currently no `freeipa-client` package for Debian Testing (currently Bookworm) or Kali.  Once Bookworm is actually released a `freeipa-client` package will appear in `bookworm-backports`.

## 🧪 Testing ##

All automated testing passes.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.