### PR TITLE
Re-enable support for Debian Bookworm and Kali Linux

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -21,16 +21,10 @@ galaxy_info:
       versions:
         - buster
         - bullseye
-        # There is currently no freeipa-client package for Debian
-        # Testing (Bookworm) or Kali.  Once Bookworm is actually
-        # released a freeipa-client will appear in bookworm-backports.
-        #
-        # See cisagov/ansible-role-freeipa-client#51
-        #
         # Kali linux isn't an option here, but it is based on
         # Debian Testing:
         # https://www.kali.org/docs/policy/kali-linux-relationship-with-debian
-        # - bookworm
+        - bookworm
     - name: Fedora
       versions:
         - "35"

--- a/molecule/default/molecule-no-systemd.yml
+++ b/molecule/default/molecule-no-systemd.yml
@@ -25,18 +25,12 @@ platforms:
   - image: debian:bullseye-slim
     name: debian11
     platform: amd64
-  # There is currently no freeipa-client package for Debian Testing
-  # (Bookworm) or Kali.  Once Bookworm is actually released a
-  # freeipa-client will appear in bookworm-backports.
-  #
-  # See cisagov/ansible-role-freeipa-client#51
-  #
-  # - image: debian:bookworm-slim
-  #   name: debian12
-  #   platform: amd64
-  # - image: kalilinux/kali-rolling
-  #   name: kali
-  #   platform: amd64
+  - image: debian:bookworm-slim
+    name: debian12
+    platform: amd64
+  - image: kalilinux/kali-rolling
+    name: kali
+    platform: amd64
   - image: fedora:35
     name: fedora35
     platform: amd64


### PR DESCRIPTION
## 🗣 Description ##

This pull request re-enables support for Debian Bookwork and Kali Linux.

## 💭 Motivation and context ##

Resolves #51.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.