### PR TITLE
Add `--force-join` flag to `ipa-client-install`

### DIFF
--- a/files/00_setup_freeipa.sh
+++ b/files/00_setup_freeipa.sh
@@ -90,7 +90,8 @@ function install {
   # "undefined variable" warning from shellcheck.
   #
   # shellcheck disable=SC2154
-  ipa-client-install --hostname="$hostname" \
+  ipa-client-install --force-join \
+    --hostname="$hostname" \
     --mkhomedir \
     --no-ntp
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds the `--force-join` flag to the `ipa-client-install` command run when joining a client to the FreeIPA domain.

## 💭 Motivation and context ##

It is annoying to have to unjoin FreeIPA clients from the domain before recreating them, and adding this option makes this no longer necessary.

## 🧪 Testing ##

All automated tests pass.  I successfully ran the `ipa-client-install` command with this additional flag on a Guacamole instance in the staging COOL.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.