### PR TITLE
Set `default_ccache_name` and edit `/etc/sssd/sssd.conf` for Debian Bookworm too

### DIFF
--- a/files/00_setup_freeipa.sh
+++ b/files/00_setup_freeipa.sh
@@ -61,22 +61,23 @@ function add_principal {
   fi
 }
 
-# Fix a bug in the sssd.conf file for Debian Bullseye
+# Fix a bug in the sssd.conf file for Debian Bullseye and later
 function fix_sssd_conf_file {
-  # On Debian Bullseye, the SSSD config file incorrectly contains a
-  # line of the form "services = ..." in the sssd section.  This line
-  # is unnecessary since we are using SystemD (as described in
+  # On Debian Bullseye and later, the SSSD config file incorrectly
+  # contains a line of the form "services = ..." in the sssd section.
+  # This line is unnecessary since we are using SystemD (as described
+  # in
   # https://manpages.debian.org/testing/sssd-common/sssd.conf.5.en.html#The_%5Bsssd%5D_section),
-  # and on Debian Bullseye its presence causes a failure.  This is
-  # because SystemD tries to enable and start those services, but they
-  # are only meant to be triggered when the corresponding SystemD
-  # *.socket units are activated.
+  # and on Debian Bullseye and later the presence of this line causes
+  # a failure.  This is because SystemD tries to enable and start
+  # those services, but they are only meant to be triggered when the
+  # corresponding SystemD *.socket units are activated.
   #
   # Note that /usr/bin/lsb_release is a Debian-specific tool, so if it
   # doesn't exist then we know we are not on Debian.
   if [[ -x /usr/bin/lsb_release ]] \
     && [[ "$(lsb_release --id | sed -e 's/^Distributor ID:[[:blank:]]*\(.*\)$/\1/')" = "Debian" ]] \
-    && [[ "$(lsb_release --codename | sed -e 's/^Codename:[[:blank:]]*\(.*\)$/\1/')" = "bullseye" ]]; then
+    && [[ "$(lsb_release --codename | sed -e 's/^Codename:[[:blank:]]*\(.*\)$/\1/')" != "buster" ]]; then
     sed -i "/^[[:blank:]]*services =/d" /etc/sssd/sssd.conf
 
     systemctl restart sssd.service

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -12,18 +12,20 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 ).get_hosts("all")
 
 
-@pytest.mark.parametrize("pkg", ["ipa-client", "sssd-tools"])
-def test_packages_amazon(host, pkg):
+def test_packages(host):
     """Test that the appropriate packages were installed."""
-    if host.system_info.distribution == "amzn":
-        assert host.package(pkg).is_installed
-
-
-@pytest.mark.parametrize("pkg", ["freeipa-client", "sssd-tools"])
-def test_packages_not_amazon(host, pkg):
-    """Test that the appropriate packages were installed."""
-    if host.system_info.distribution != "amzn":
-        assert host.package(pkg).is_installed
+    distribution = host.system_info.distribution
+    if host.system_info.distribution in ["amzn"]:
+        pkgs = ["ipa-client", "sssd-tools"]
+    elif distribution in ["debian", "fedora", "kali", "ubuntu"]:
+        pkgs = ["freeipa-client", "sssd-tools"]
+    else:
+        # We don't support this distribution
+        assert False, f"Unknown distribution {distribution}"
+    packages = [host.package(pkg) for pkg in pkgs]
+    installed = [package.is_installed for package in packages]
+    assert len(pkgs) != 0
+    assert all(installed)
 
 
 @pytest.mark.parametrize(

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -15,7 +15,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 def test_packages(host):
     """Test that the appropriate packages were installed."""
     distribution = host.system_info.distribution
-    if host.system_info.distribution in ["amzn"]:
+    if distribution in ["amzn"]:
         pkgs = ["ipa-client", "sssd-tools"]
     elif distribution in ["debian", "fedora", "kali", "ubuntu"]:
         pkgs = ["freeipa-client", "sssd-tools"]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,19 +15,19 @@
     - name: Install FreeIPA client
       ansible.builtin.package:
         name: "{{ package_names }}"
-    # On Debian Bullseye, the default /etc/krb5.conf file uses a FILE
-    # value for this option.  The /etc/krb5.conf file is then
-    # overwritten when the 00_setup_freeipa.sh script is run, and the
-    # new file uses the KEYRING value specified below.  This causes a
-    # problem since before running that script we kinit, which stores
-    # our keytab in a file that is then ignored by Kerberos due to the
-    # new configuration.  To avoid this wrinkle we simply adjust the
-    # default configuration to use the preferred value before the
-    # script can ever be run.
-    - name: Set default ccache name for Kerberos (Debian Bullseye only)
+    # On Debian Bullseye and later, the default /etc/krb5.conf file
+    # uses a FILE value for this option.  The /etc/krb5.conf file is
+    # then overwritten when the 00_setup_freeipa.sh script is run, and
+    # the new file uses the KEYRING value specified below.  This
+    # causes a problem since before running that script we kinit,
+    # which stores our keytab in a file that is then ignored by
+    # Kerberos due to the new configuration.  To avoid this wrinkle we
+    # simply adjust the default configuration to use the preferred
+    # value before the script can ever be run.
+    - name: Set default ccache name for Kerberos (Debian Bullseye and later)
       community.general.ini_file:
         # These are the permissions that are set by default on
-        # Debian Bullseye.
+        # Debian Bullseye and later.
         mode: 0644
         option: default_ccache_name
         path: /etc/krb5.conf
@@ -35,7 +35,7 @@
         value: KEYRING:persistent:%{uid}
       when:
         - ansible_distribution == "Debian"
-        - ansible_distribution_release == "bullseye"
+        - ansible_distribution_release != "buster"
 
 - name: Copy setup script
   ansible.builtin.copy:


### PR DESCRIPTION
## 🗣 Description ##

This pull request extends to Debian Bullseye and later two changes that were made only to Debian Bullseye in #42.

## 💭 Motivation and context ##

In #42 we added:
- Some Ansible code to fix a bug of sorts in `/etc/krb5.conf`
- Some `bash` code to fix an error `/etc/sssd/sssd.conf` for Debian Bullseye

Debian Bookworm needs these changes too.

## 🧪 Testing ##

All automated tests pass.  I also built a new Guacamole staging AMI with these changes, deployed it to env6 in our staging COOL environment, and verified that it functions as expected.  It did not function as expected without these changes.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.